### PR TITLE
Add BSD (3 clause) license, and comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2019 Fedora CoreOS Authors. All rights reserved.
+Copyright (c) 2013 The CoreOS Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/usr/lib/console-login-helper-messages/issuegen
+++ b/usr/lib/console-login-helper-messages/issuegen
@@ -3,6 +3,14 @@
 # Get updated system information, including SSH keys and network devices,
 # and generate an issue to display before login.
 
+# Copyright (c) 2019 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2013 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# Modified from the CoreOS repository:
+#  * https://github.com/coreos/init/blob/master/scripts/issuegen
+#  * https://github.com/coreos/init/blob/master/scripts/sshd_keygen
+
 set -e
 
 PKG_NAME=console-login-helper-messages
@@ -11,6 +19,9 @@ ISSUE_DIR_PRIVATE=${PKG_NAME}/issue.d
 GENERATED_ISSUE=/run/${ISSUE_DIR_PUBLIC}/${PKG_NAME}.issue
 SSH_DIR=/etc/ssh
 
+# The public directories are to be read by higher-level programs to display
+# the issue on login, e.g. agetty.
+# The private directories are to be read only by this script.
 mkdir -p ${SSH_DIR}
 mkdir -p /run/${ISSUE_DIR_PUBLIC}
 mkdir -p /run/${ISSUE_DIR_PRIVATE}

--- a/usr/lib/console-login-helper-messages/motdgen
+++ b/usr/lib/console-login-helper-messages/motdgen
@@ -1,26 +1,36 @@
 #!/bin/bash
 
-# Get updated system information from package managers
-# and generate a motd to display this at login.
+# Copyright (c) 2019 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2014 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# Modified from the CoreOS repository: https://github.com/coreos/init/blob/master/scripts/motdgen
+
+# Get updated system information and generate a motd
+# to display this at login.
 
 set -e
 
+# The public directories are to be read by higher-level programs to display
+# the motd on login, e.g. sshd and login.
+# The private directories are to be read only by this script.
 PKG_NAME=console-login-helper-messages
 MOTD_DIR_PUBLIC=motd.d
 MOTD_DIR_PRIVATE=${PKG_NAME}/motd.d
 GENERATED_MOTD=/run/${MOTD_DIR_PUBLIC}/${PKG_NAME}.motd
-
-source /usr/lib/os-release
 
 mkdir -p /run/${MOTD_DIR_PRIVATE}
 mkdir -p /run/${MOTD_DIR_PUBLIC}
 rm -f ${GENERATED_MOTD}
 touch ${GENERATED_MOTD}
 
+source /usr/lib/os-release
 echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m (${VERSION})" > ${GENERATED_MOTD}
 
 echo >> ${GENERATED_MOTD}
 
+# Generate a motd from files found in the private (package-specific) directories,
+# and place the motd in a public directory.
 if [[ -d "/etc/${MOTD_DIR_PRIVATE}" ]]; then
 	cat /etc/${MOTD_DIR_PRIVATE}/* 2>/dev/null >> ${GENERATED_MOTD} || true
 fi

--- a/usr/share/console-login-helper-messages/profile.sh
+++ b/usr/share/console-login-helper-messages/profile.sh
@@ -1,5 +1,7 @@
 # /usr/share/console-login-helper-messages/profile.sh
 
+# Originally from https://github.com/coreos/baselayout/blob/master/baselayout/coreos-profile.sh
+
 # Only print for interactive shells.
 if [[ $- == *i* ]]; then
 	FAILED=$(systemctl list-units --state=failed --no-legend)


### PR DESCRIPTION
Adds the BSD (3 clause) license with Fedora CoreOS copyright, which originally came from https://github.com/coreos/init/blob/master/LICENSE (the repository where motdgen and issuegen existed in CL before).

Checked that the license is listed in Fedora https://fedoraproject.org/wiki/Licensing:BSD?rd=Licensing/BSD#3ClauseBSD, so it doesn't look like there should be any problem.